### PR TITLE
build: add bazel config for stamping

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,5 @@
 build --strategy=TypeScriptCompile=worker
 test --test_output=errors
+
+build:release --stamp
+build:release --workspace_status_command=./tools/bazel_stamp_vars.sh

--- a/tools/bazel_stamp_vars.sh
+++ b/tools/bazel_stamp_vars.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo BUILD_SCM_VERSION $(git describe --abbrev=7 --tags HEAD)


### PR DESCRIPTION
Adds workspace status command for stamping from tags

relates to #4 