### PR TITLE
fix: limit choices for build_file_name flag

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -322,7 +322,8 @@ export const setupAndParseArgs = (argv: string[], ignorerc = false, strip = 2): 
       type: 'string',
       description: 'The name to use for bazel build files',
       default: 'BUILD',
-      group: 'Configuration'
+      group: 'Configuration',
+      choices: ['BUILD', 'BUILD.bazel']
     })
     .option('buildozer_commands_file', {
       type: 'string',


### PR DESCRIPTION
Limits the choices for the `--build_file_name` flag to `BUILD` (the current default) and `BUILD.bazel`