### PR TITLE
build: update nodejs version to 12.13.0 lts

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,7 +14,7 @@ http_archive(
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
 
 node_repositories(
-    node_version = "10.16.0",
+    node_version = "12.13.0",
     package_json = ["//:package.json"],
     yarn_version = "1.19.1",
 )


### PR DESCRIPTION
Updates to the LTS version of NodeJS that is a default in rules_nodejs. 

This is mainly so our internal builds in ev match their public counterparts. I don't think bzlgen has any requirements for this version of Node, but it doesn't hurt to keep them consistent. 