### PR TITLE
chore: update .gitingore to include .ijwb and tools/bazel_version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 bazel-*
 .idea
-yarn-error.log
+.ijwb
 .vscode
+yarn-error.log
+tools/bazel_version


### PR DESCRIPTION
`.gitignore` the IJ workspace dirs, as well as ebazel's version file (although not commited)

closes #8