### PR TITLE
feat: support globs in static label mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ mapping between a source file and its label. Labels mappings are always the rela
 --label_mapping path/to/src/component.ts=//some/other:label
 ```
 
+Mappings can also contain glob patterns, allowing many paths or subpaths to be mapped to a specific label.
+The example below will map all files in the `path/to` subdirectory to the label `//:foo`
+
+```
+--label_mapping path/to/**/*=//:foo
+```
+
 Imports can be ignored by setting the path to a blank label
 
 #### Bazel Query

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@phenomnomnominal/tsquery": "3.0.0",
     "gonzales-pe": "4.2.4",
     "lodash.kebabcase": "4.1.1",
+    "minimatch": "3.0.4",
     "shelljs": "0.8.3",
     "signale": "1.4.0",
     "typescript": "3.6.4",
@@ -24,9 +25,10 @@
     "@bazel/jasmine": "1.1.0",
     "@bazel/typescript": "1.1.0",
     "@types/jasmine": "3.5.0",
-    "@types/shelljs": "0.8.6",
+    "@types/minimatch": "3.0.3",
     "@types/mock-fs": "4.10.0",
     "@types/node": "12.7.8",
+    "@types/shelljs": "0.8.6",
     "mock-fs": "4.10.4"
   },
   "license": "MIT"

--- a/src/BUILD
+++ b/src/BUILD
@@ -9,6 +9,7 @@ RUNTIME_NPM_DEPS = [
     "@npm//gonzales-pe",
     "@npm//@phenomnomnominal/tsquery",
     "@npm//typescript",
+    "@npm//minimatch",
 ]
 
 ts_library(
@@ -22,6 +23,7 @@ ts_library(
     deps = [
         "@npm//@types/node",
         "@npm//@types/shelljs",
+        "@npm//@types/minimatch",
     ] + RUNTIME_NPM_DEPS,
     module_name = "@evertz/bzlgen/src",
 )

--- a/test/workspace.spec.ts
+++ b/test/workspace.spec.ts
@@ -11,7 +11,8 @@ describe('workspace', () => {
     const argv = [
       '--base_dir=/home/workspace',
       '--no-assert_is_bazel_workspace',
-      '--label_mapping=src/baz=//other'
+      '--label_mapping=src/baz=//other',
+      '--label_mapping=src/foo/*=//fother'
     ];
 
     const pathArgv = [
@@ -33,8 +34,12 @@ describe('workspace', () => {
     mockfs({
       '/home/workspace': {
         src: {
-          component: { 'foo.component.scss': '' },
-          foo: {},
+          component: {
+            'foo.component.scss': ''
+          },
+          foo: {
+            'some-file.ts': ''
+          },
           baz: {}
         },
         test: {
@@ -115,6 +120,11 @@ describe('workspace', () => {
     it('can resolve static label mappings', () => {
       expect(pathWorkspace.getLabelFor('../baz').toString()).toBe('//other:other');
       expect(fileWorkspace.getLabelFor('../baz').toString()).toBe('//other:other');
+    });
+
+    it('can resolve static label mappings with globs', () => {
+      // without the glob this resolves to //src/foo:foo
+      expect(pathWorkspace.getLabelFor('../foo/some-file.ts').toString()).toBe('//fother:fother');
     });
 
     it('can resolve labels for files', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,7 +110,7 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
   integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
 
-"@types/minimatch@*":
+"@types/minimatch@*", "@types/minimatch@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -592,7 +592,7 @@ mimic-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4:
+minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==


### PR DESCRIPTION
Adds support for glob patterns in the static label mappings. The results of matched imports are cached against the label for faster lookup when generating multiple targets, and for future use...

Finding the mapping is done via 'find' which (as the comment in the code indicates), returns the first truthy value, meaning there may be a more specific glob further down the list, the consumer will have to move the glob higher in the label mappings list.
 
closes #15