### PR TITLE
feat: support tsconfig path mappings

### DIFF
--- a/.bzlgenrc
+++ b/.bzlgenrc
@@ -5,4 +5,4 @@
 --ng_module_bundle_load=//tools/rules_bazel/defs.bzl
 
 # label mappings
---label_mapping=rxjs/operators=@npm//rxjs
+--label_mapping=rxjs/*=@npm//rxjs

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "shelljs": "0.8.3",
     "signale": "1.4.0",
     "typescript": "3.8.3",
+    "tsconfig-paths": "3.9.0",
     "yargs": "14.2.0"
   },
   "devDependencies": {

--- a/src/BUILD
+++ b/src/BUILD
@@ -10,6 +10,7 @@ RUNTIME_NPM_DEPS = [
     "@npm//@phenomnomnominal/tsquery",
     "@npm//typescript",
     "@npm//minimatch",
+    "@npm//tsconfig-paths",
 ]
 
 ts_library(

--- a/src/generators/generator.ts
+++ b/src/generators/generator.ts
@@ -1,6 +1,17 @@
-import { GeneratorType } from '../flags';
+import { Flags, GeneratorType } from '../flags';
+import { Workspace } from '../workspace';
+import { Buildozer } from '../buildozer';
 
 export abstract class BuildFileGenerator {
+  private readonly flags: Flags;
+
+  protected readonly buildozer: Buildozer;
+
+  protected constructor(protected readonly workspace: Workspace) {
+    this.buildozer = workspace.getBuildozer();
+    this.flags = workspace.getFlags();
+  }
+
   /**
    * Run any validation rules here on the current flags or workspace
    * If an error is thrown then the message is printed to the user and the generator exits with code 1,

--- a/src/generators/sass/sass.generator.ts
+++ b/src/generators/sass/sass.generator.ts
@@ -1,18 +1,14 @@
 import * as gonzales from 'gonzales-pe';
 import { ParsedPath } from 'path';
 
-import { Buildozer } from '../../buildozer';
 import { GeneratorType } from '../../flags';
 import { log } from '../../logger';
 import { Workspace } from '../../workspace';
 import { BuildFileGenerator } from '../generator';
 
 export class SassGenerator extends BuildFileGenerator {
-  private readonly buildozer: Buildozer;
-
-  constructor(private readonly workspace: Workspace) {
-    super();
-    this.buildozer = workspace.getBuildozer();
+  constructor(workspace: Workspace) {
+    super(workspace);
   }
 
   async generate(): Promise<void> {

--- a/src/generators/ts/ts.generator.flags.ts
+++ b/src/generators/ts/ts.generator.flags.ts
@@ -10,6 +10,11 @@ export function setupGeneratorCommand(y) {
     description: 'The label used for any tsconfig attrs',
     requiresArg: true,
     group: 'TS Generator'
+  }).option('ts_config', {
+    type: 'string',
+    description: 'Path to a tsconfig.json file that is used to attempt to resolve path mappings',
+    requiresArg: true,
+    group: 'TS Generator'
   });
 }
 
@@ -23,4 +28,9 @@ export interface TsGeneratorFlags {
    * The label used for any tsconfig attrs
    */
   ts_config_label: string;
+
+  /**
+   * Path (relative to base_dir) to a tsconfig.json file that is used to attempt to resolve path mappings
+   */
+  ts_config: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,7 @@ export async function run() {
   }
 
   const isValid = generator.validate();
+
   if (isValid) {
     await wrap('generate', async () => await generator.generate());
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -13,7 +13,7 @@ import { debug, fatal, isDebugEnabled, lb, log, warn } from './logger';
 export class Workspace {
   private readonly buildozer: Buildozer;
 
-  private readonly staticLabels: Map<RegExp, string>;
+  private readonly staticLabels: Map<string, RegExp>;
   private readonly resolvedStaticLabelsCache: Map<string, Label> = new Map<string, Label>();
 
   private readonly fileQueryResultCache: Map<string, Label> = new Map<string, Label>();
@@ -23,8 +23,8 @@ export class Workspace {
   constructor(private readonly flags: Flags) {
     this.buildozer = new Buildozer(this.flags.load_mapping);
 
-    const regexLabels: Array<[RegExp, string]> = Array.from(this.flags.label_mapping.entries())
-      .map(pair => [minimatch.makeRe(pair[0]), pair[1]]);
+    const regexLabels: Array<[string, RegExp]> = Array.from(this.flags.label_mapping.entries())
+      .map(pair => [pair[1], minimatch.makeRe(pair[0])]);
 
     this.staticLabels = new Map(regexLabels);
     
@@ -313,17 +313,17 @@ export class Workspace {
       return this.resolvedStaticLabelsCache.get(imp);
     }
 
-    // find returns the first found truthy match, so there _may_ be a more speciffic glob in the map
+    // find returns the first found truthy match, so there _may_ be a more specific glob in the map
     // but we won't find it - room for improvement, but the consumer can move them up the list
     const result = Array.from(this.staticLabels.entries())
-      .find(([key, _]) => !!key.exec(imp));
+      .find(([_, value]) => !!value.exec(imp));
 
     if (!result) {
       return defaultValue ? Label.parseAbsolute(defaultValue) : undefined;
     }
 
-    const staticMaped = result[1];
-    const label = Label.parseAbsolute(staticMaped);
+    const staticMapped = result[0];
+    const label = Label.parseAbsolute(staticMapped);
 
     this.resolvedStaticLabelsCache.set(imp, label);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,11 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.5.0.tgz#2ad2006c8a937d20df20a8fee86071d0f730ef99"
   integrity sha512-kGCRI9oiCxFS6soGKlyzhMzDydfcPix9PpTkr7h11huxOxhWwP37Tg7DYBaQ18eQTNreZEuLkhpbGSqVNZPnnw==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
@@ -529,6 +534,13 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
+
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -617,6 +629,11 @@ minimist@1.1.x:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
   integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
+
+minimist@^1.2.0:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minimist@~0.0.1:
   version "0.0.10"
@@ -1075,6 +1092,16 @@ test-exclude@^5.2.2:
     minimatch "^3.0.4"
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
+
+tsconfig-paths@3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.8.1:
   version "1.10.0"


### PR DESCRIPTION
Adds support for using `tsconfig.json#path` attribute in order to map import paths to labels.

The mapping is resolved first though `tsconfig.json`, the result of this mapping is then passed back though the label resolution process.

closes #22 

// cc @Toxicable 