### PR TITLE
feat: support generating simple nodejs_binary targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The generator can create rules for the following and can be extended to provide 
 * sass_binary
 * ng_module
 * ts_library
+* nodejs_binary
 
 The generator is _somewhat_ flexible in the source structure, but does make a number of assumptions in certain cases.
 It will try and 'best guess' labels from other packages. It's currently not expected to generate a 100% correct and working build file,

--- a/src/buildozer.ts
+++ b/src/buildozer.ts
@@ -4,8 +4,9 @@ import { Label } from './label';
 const DEFAULT_LOAD_SITES = new Map<string, string>([
   ['sass_library', '@io_bazel_rules_sass//sass:sass.bzl'],
   ['sass_binary', '@io_bazel_rules_sass//sass:sass.bzl'],
-  ['ts_library', '@npm_bazel_typescript//:defs.bzl'],
+  ['ts_library', '@npm_bazel_typescript//:index.bzl'],
   ['ng_module', '@npm_angular_bazel//:index.bzl'],
+  ['nodejs_binary', '@build_bazel_rules_nodejs//:index.bzl'],
 ]);
 
 /**

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -11,7 +11,8 @@ export enum GeneratorType {
   NG = 'ng',
   NG_BUNDLE = 'ng_bundle',
   SASS = 'sass',
-  TS = 'ts'
+  TS = 'ts',
+  JS_BINARY = 'js_binary'
 }
 
 function coerceMappingFlag(loads: string[]): Map<string, string> {

--- a/src/generators/generator.ts
+++ b/src/generators/generator.ts
@@ -3,11 +3,10 @@ import { Workspace } from '../workspace';
 import { Buildozer } from '../buildozer';
 
 export abstract class BuildFileGenerator {
-  private readonly flags: Flags;
-
+  protected readonly flags: Flags;
   protected readonly buildozer: Buildozer;
 
-  protected constructor(protected readonly workspace: Workspace) {
+  constructor(protected readonly workspace: Workspace) {
     this.buildozer = workspace.getBuildozer();
     this.flags = workspace.getFlags();
   }

--- a/src/generators/js/nodejs-binary.generator.ts
+++ b/src/generators/js/nodejs-binary.generator.ts
@@ -1,0 +1,27 @@
+import { GeneratorType } from '../../flags';
+import { BuildFileGenerator } from '../generator';
+
+export class NodejsBinaryGenerator extends BuildFileGenerator {
+
+  async generate(): Promise<void> {
+    const label = this.workspace.getLabelForPath().withTarget('bin');
+    const path = this.flags.path;
+
+    this.buildozer.loadRule('nodejs_binary', label);
+    this.buildozer.newRule('nodejs_binary', label);
+
+    this.buildozer.setAttr('entry_point',
+      this.workspace.getFileLabel(path).toString(), label);
+
+    this.buildozer.addAttr('data',
+      [this.workspace.getLabelForFile(path).toString()], label);
+  }
+
+  getGeneratorType(): GeneratorType {
+    return GeneratorType.JS_BINARY;
+  }
+
+  supportsDirectories(): boolean {
+    return false;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { inspect } from 'util';
 
 import { setupAndParseArgs, Flags, GeneratorType } from './flags';
 import { BuildFileGenerator } from './generators/generator';
+import { NodejsBinaryGenerator } from './generators/js/nodejs-binary.generator';
 import { NgGenerator } from './generators/ng/ng.generator';
 import { SassGenerator } from './generators/sass/sass.generator';
 import { TsGenerator } from './generators/ts/ts.generator';
@@ -32,6 +33,8 @@ function getGenerator(type: GeneratorType, workspace: Workspace): BuildFileGener
     case GeneratorType.NG:
     case GeneratorType.NG_BUNDLE:
       return new NgGenerator(workspace);
+    case GeneratorType.JS_BINARY:
+      return new NodejsBinaryGenerator(workspace);
     default:
       fatal(`No generator found for type ${type}`);
   }

--- a/test/buildozer.spec.ts
+++ b/test/buildozer.spec.ts
@@ -43,7 +43,7 @@ describe('buildozer', () => {
 
     const commands = batch.flatMap(item => item.commands).join('\n');
     const expected =
-      'new_load @npm_bazel_typescript//:defs.bzl ts_library\n' +
+      'new_load @npm_bazel_typescript//:index.bzl ts_library\n' +
       'new ts_library bar\n' +
       'add deps baz\n' +
       'add srcs foo.ts\n' +


### PR DESCRIPTION
Adds support for generating `nodejs_binary` targets, setting `data` attr to the generating rule for the file at `entry_point`