### PR TITLE
fix: default to using the default label for a package as dep labels

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -24,7 +24,7 @@ function coerceMappingFlag(loads: string[]): Map<string, string> {
 
 const RC_FILE_NAME = '.bzlgenrc';
 
-interface CommonFlags {
+export interface CommonFlags {
   /*
    * Common Flags
    * Affects all rule generation
@@ -94,6 +94,14 @@ interface CommonFlags {
    * The name to use for bazel build files, eg BUILD or BUILD.bazel
    */
   build_file_name: string;
+
+  /**
+   * When generating best guess dependency labels, treat the dependency labels as though there is a BUILD file for each
+   * directory and use the package default label - //my/package:package
+   * If false, then the filename is considered to be the target for the dependency label - //my/package:main
+   * Defaults true
+   */
+  pkg_default_dep_labels: boolean;
 
   /**
    * Path to write the buildozer command file
@@ -348,6 +356,11 @@ export const setupAndParseArgs = (argv: string[], ignorerc = false, strip = 2): 
       type: 'boolean',
       description: 'Use bazel query to try and resolve labels for source files',
       default: false
+    })
+    .option('pkg_default_dep_labels', {
+      type: 'boolean',
+      description: 'When generating best guess dependency labels, treat the dependency labels as though there is a BUILD file for each directory',
+      default: true
     })
     // verbosity flags
     .option('canonicalize_flags', {

--- a/src/generators/ts/ts.generator.ts
+++ b/src/generators/ts/ts.generator.ts
@@ -127,7 +127,9 @@ export class TsGenerator extends BuildFileGenerator {
 
     if (relative) {
       label = this.workspace.getLabelForFile(imp + '.ts');
-      if (label) { return label; }
+      if (label) {
+        return this.flags.pkg_default_dep_labels ? label.asDefaultLabel() : label;
+      }
 
       throw new Error (`Unable to generate label for: ${imp}`)
     } else {


### PR DESCRIPTION
fixes #20 

// cc @Toxicable 