### PR TITLE
fix: add missing descriptions to all generators

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -319,17 +319,14 @@ export const setupAndParseArgs = (argv: string[], ignorerc = false, strip = 2): 
     .option('ignore_spec_files', {
       type: 'boolean',
       description: 'Ignores spec files from import resolution and generation',
-      default: true
-    })
-    .option('use_bazel_query', {
-      type: 'boolean',
-      description: 'Use bazel query to try and resolve labels for source files',
-      default: false
+      default: true,
+      group: 'Configuration'
     })
     .option('pkg_default_dep_labels', {
       type: 'boolean',
       description: 'When generating best guess dependency labels, treat the dependency labels as though there is a BUILD file for each directory',
-      default: true
+      default: true,
+      group: 'Configuration'
     })
     // verbosity flags
     .option('canonicalize_flags', {
@@ -382,6 +379,12 @@ export const setupAndParseArgs = (argv: string[], ignorerc = false, strip = 2): 
       default: 'buildifier',
       requiresArg: true,
       group: 'Finalization'
+    })
+    .option('use_bazel_query', {
+      type: 'boolean',
+      description: 'Use bazel query to try and resolve labels for source files',
+      default: false,
+      group: 'Experimental'
     })
     .wrap(yargs.terminalWidth())
     .version();

--- a/src/generators/builtin/filegroup.generator.ts
+++ b/src/generators/builtin/filegroup.generator.ts
@@ -24,9 +24,7 @@ export class FilegroupGenerator extends BuildFileGenerator {
 
     this.buildozer.addAttr('srcs', files, label);
 
-    if (this.getFlags().default_visibility) {
-      this.buildozer.setVisibility([this.getFlags().default_visibility], label);
-    }
+    this.setDefaultVisibilityOn(label);
   }
 
   getGeneratorType(): GeneratorType | string {

--- a/src/generators/containers/container-layer.generator.ts
+++ b/src/generators/containers/container-layer.generator.ts
@@ -2,7 +2,10 @@ import { BuildFileGenerator } from '../generator';
 import { Generator } from '../resolve-generator';
 import { GeneratorType } from '../types';
 
-@Generator({ type: GeneratorType.CONTAINER_LAYER })
+@Generator({
+  type: GeneratorType.CONTAINER_LAYER,
+  description: 'Generates a container_layer rule containing all the files captured by the path parameter'
+})
 export class ContainerLayerGenerator extends BuildFileGenerator {
 
   async generate(): Promise<void> {
@@ -22,6 +25,8 @@ export class ContainerLayerGenerator extends BuildFileGenerator {
     }
 
     this.buildozer.addAttr('files', files, label);
+
+    this.setDefaultVisibilityOn(label);
   }
 
   getGeneratorType(): GeneratorType {

--- a/src/generators/generator.ts
+++ b/src/generators/generator.ts
@@ -2,16 +2,13 @@ import { Flags } from '../flags';
 import { Workspace } from '../workspace';
 import { Buildozer } from '../buildozer';
 import { GeneratorType } from './types';
+import { Label } from '../label';
 
 export abstract class BuildFileGenerator {
   protected readonly buildozer: Buildozer;
 
   constructor(protected readonly workspace: Workspace) {
     this.buildozer = workspace.getBuildozer();
-  }
-
-  protected getFlags<T>(): Flags<T> {
-    return this.workspace.getFlags<T>();
   }
 
   /**
@@ -37,4 +34,21 @@ export abstract class BuildFileGenerator {
    * Return if this generator supports directories
    */
   public abstract supportsDirectories(): boolean;
+
+  /**
+   * Returns the set of flags associated with this run
+   */
+  protected getFlags<T>(): Flags<T> {
+    return this.workspace.getFlags<T>();
+  }
+
+  /**
+   * Sets the visibility of the rule at 'label' to the visibility set at the --default_visibility flag
+   * @param label
+   */
+  protected setDefaultVisibilityOn(label: Label) {
+    if (this.getFlags().default_visibility) {
+      this.buildozer.setVisibility([this.getFlags().default_visibility], label);
+    }
+  }
 }

--- a/src/generators/js/nodejs-binary.generator.ts
+++ b/src/generators/js/nodejs-binary.generator.ts
@@ -2,7 +2,10 @@ import { BuildFileGenerator } from '../generator';
 import { Generator } from '../resolve-generator';
 import { GeneratorType } from '../types';
 
-@Generator({ type: GeneratorType.JS_BINARY })
+@Generator({
+  type: GeneratorType.JS_BINARY,
+  description: 'Generates a nodejs_binary rule setting the entry_point to the file at the given path'
+})
 export class NodejsBinaryGenerator extends BuildFileGenerator {
 
   async generate(): Promise<void> {

--- a/src/generators/ng/ng.generator.ts
+++ b/src/generators/ng/ng.generator.ts
@@ -1,7 +1,6 @@
 import { tsquery } from '@phenomnomnominal/tsquery';
 import { parse } from 'path';
 import { StringLiteral } from 'typescript';
-import { Flags } from '../../flags';
 
 import { fatal } from '../../logger';
 import { Workspace } from '../../workspace';
@@ -21,8 +20,14 @@ type TsFileResultContainer = {
 };
 
 @Generator({
-  type: [GeneratorType.NG, GeneratorType.NG_BUNDLE],
-  flags: NgGeneratorFlagBuilder
+  type: GeneratorType.NG,
+  flags: NgGeneratorFlagBuilder,
+  description: 'Generates a ng_module rule for an Angular component'
+})
+@Generator({
+  type: GeneratorType.NG_BUNDLE,
+  flags: NgGeneratorFlagBuilder,
+  description: 'Generates a ng_module macro rule for an Angular component'
 })
 export class NgGenerator extends TsGenerator {
 

--- a/src/generators/resolve-generator.ts
+++ b/src/generators/resolve-generator.ts
@@ -18,7 +18,7 @@ export type FlagBuilder = { [flag: string]: FlagOptions };
 export interface Ref<T extends typeof BuildFileGenerator> {
   generator: T;
   type: GeneratorType | string;
-  description?: string;
+  description: string;
   flags?: FlagBuilder;
 }
 
@@ -35,7 +35,7 @@ export function getGenerator(type: GeneratorType, workspace: Workspace): BuildFi
 }
 
 export function Generator(options:
-                            { type: GeneratorType | string | Array<string | GeneratorType>, flags?: FlagBuilder, description?: string }) {
+                            { type: GeneratorType | string | Array<string | GeneratorType>, flags?: FlagBuilder, description: string }) {
   return function (generator) {
     if (Array.isArray(options.type)) {
       options.type.forEach(type => {

--- a/src/generators/sass/sass.generator.ts
+++ b/src/generators/sass/sass.generator.ts
@@ -11,7 +11,8 @@ import { SassGeneratorFlagBuilder, SassGeneratorFlags } from './sass.generator.f
 
 @Generator({
   type: GeneratorType.SASS,
-  flags: SassGeneratorFlagBuilder
+  flags: SassGeneratorFlagBuilder,
+  description: 'Generates a sass_binary or sass_library depending on the input path type'
 })
 export class SassGenerator extends BuildFileGenerator {
   private readonly flags: Flags<SassGeneratorFlags>;

--- a/src/generators/ts/ts.generator.ts
+++ b/src/generators/ts/ts.generator.ts
@@ -28,7 +28,8 @@ const EXPORTS_QUERY = `ExportDeclaration:has(StringLiteral)`;
 
 @Generator({
   type: GeneratorType.TS,
-  flags: TsGeneratorFlagBuilder
+  flags: TsGeneratorFlagBuilder,
+  description: 'Generates a ts_library for the files or file at path'
 })
 export class TsGenerator extends BuildFileGenerator {
   protected readonly tsPathsMatcher: MatchPath;


### PR DESCRIPTION
Adds missing descriptions to the current set of generators. Makes the `description` attr non-optional