### PR TITLE
fix: filter @angular/core, @angular/common and rxjs dependencies when…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### 0.0.0-PLACEHOLDER
 
+* **fix**: Remove @angular/core, @angular/common and rxjs dependencies when generating with the ng_bundle generator as these deps are already included by default
+
 #### 0.5.0
 
 * **fix**: Don't evict unknown rule loads from load mappings

--- a/src/generators/ng/ng.generator.ts
+++ b/src/generators/ng/ng.generator.ts
@@ -188,7 +188,13 @@ export class NgGenerator extends TsGenerator {
     this.buildozer.newLoad(flags.ng_module_bundle_load, 'ng_module', pathLabel);
     this.buildozer.newRule('ng_module', pathLabel);
     this.buildozer.addAttr('srcs', tsFiles.map(file => file.split('/').pop()), pathLabel);
-    this.buildozer.addAttr('deps', Array.from(resultContainer.tsDeps), pathLabel);
+
+    const deps = Array.from(resultContainer.tsDeps)
+      .filter(dep => !(dep.endsWith('@angular/core:core') || dep.endsWith('@angular/common:common') || dep.endsWith('rxjs:rxjs')));
+
+    if (deps.length) {
+      this.buildozer.addAttr('deps', deps, pathLabel);
+    }
 
     if (resultContainer.styles.size) {
       // ng_module macro only supports one style

--- a/test/generators/ng.generator.spec.ts
+++ b/test/generators/ng.generator.spec.ts
@@ -91,7 +91,6 @@ import { SomeComponent } from './component.component';
       'new_load //tools/rules_bazel/defs.bzl ng_module|//src/component:__pkg__\n' +
       'new ng_module component|//src/component:__pkg__\n' +
       'add srcs component.component.ts component.module.ts|//src/component:component\n' +
-      'add deps @npm//@angular/core:core @npm//rxjs:rxjs|//src/component:component\n' +
       'set style "component.component.scss"|//src/component:component\n' +
       'add assets component.component.html|//src/component:component\n' +
       'set theme "component.theme.scss"|//src/component:component';


### PR DESCRIPTION
… generating with the ng_bundle generator as these deps are already included by default