### PR TITLE
fix: handle double quotes when resolving imports within Typescript files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### 0.0.0-PLACEHOLDER
 
 * **fix**: Remove @angular/core, @angular/common and rxjs dependencies when generating with the ng_bundle generator as these deps are already included by default
+* **fix**: Handle double quotes when resolving imports within Typescript files
 
 #### 0.5.0
 

--- a/src/generators/ts/ts.generator.ts
+++ b/src/generators/ts/ts.generator.ts
@@ -101,8 +101,7 @@ export class TsGenerator extends BuildFileGenerator {
   }
 
   private resolveLabelFromModuleSpecifier(moduleSpecifier: Expression, tsFiles: string[] = [], npmWorkspace: string): Label | undefined {
-    const moduleSpecifierText = moduleSpecifier.getText().split(`'`)[1];
-
+    const moduleSpecifierText = moduleSpecifier.getText().replace(/['"]+/g, '');
     const workspaceRelativeImport = this.workspace.resolveRelativeToWorkspace(moduleSpecifierText);
     if (
       tsFiles.includes(

--- a/test/generators/ts.generator.spec.ts
+++ b/test/generators/ts.generator.spec.ts
@@ -69,6 +69,33 @@ export class Some {}
     expect(commands.join('\n')).toEqual(expected);
   });
 
+  it('can handle imports with double and single quotes', async () => {
+    mockfs({
+      '/home/workspace/src/some': {
+        'one.ts': 'import { NgModule } from "@angular/core";\nimport * as r from \'rxjs/operators\'',
+        'component.component.scss': '',
+        'component.component.html': '',
+        'component.theme.scss': ''
+      },
+      '/home/workspace/src/other': {
+        'foo.ts': '',
+      }
+    });
+
+    await gen.generate();
+
+    const commands = workspace.getBuildozer().toCommands();
+
+    const expected =
+      'new_load @npm//bazel/typescript:index.bzl ts_library|//src/some:__pkg__\n' +
+      'new ts_library some|//src/some:__pkg__\n' +
+      'add srcs one.ts|//src/some:some\n' +
+      'add deps @npm//@angular/core:core @npm//rxjs:rxjs|//src/some:some\n' +
+      'set tsconfig "//:tsconfig"|//src/some:some';
+
+    expect(commands.join('\n')).toEqual(expected);
+  });
+
   it('can use tsconfig paths', async () => {
     mockfs({
       '/home/workspace': {


### PR DESCRIPTION
Handle double quoted import specifies when resolving imports from Typescript files

fixes: #57 