### PR TITLE
build: enable esModuleInterop and change imports to match

### DIFF
--- a/src/generators/ts/ts.generator.ts
+++ b/src/generators/ts/ts.generator.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs';
 import { join, parse, posix } from 'path';
 import { tsquery } from '@phenomnomnominal/tsquery';
-import * as Builtins from 'builtins';
+import Builtins from 'builtins';
 import { createMatchPath, MatchPath } from 'tsconfig-paths';
 import {
   ExportDeclaration,

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,9 +1,9 @@
 import { lstatSync, readdirSync, readFileSync } from 'fs';
-import * as kebabCase from 'lodash.kebabcase';
+import kebabCase from 'lodash.kebabcase';
 import { isAbsolute, join, normalize, parse, sep, ParsedPath } from 'path';
 import * as shell from 'shelljs';
 import * as util from 'util';
-import * as minimatch from 'minimatch';
+import minimatch from 'minimatch';
 import * as BazelBuildozer from '@bazel/buildozer';
 
 import { Buildozer } from './buildozer';

--- a/test/generators/bzl-library.generator.spec.ts
+++ b/test/generators/bzl-library.generator.spec.ts
@@ -1,4 +1,4 @@
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 
 import { Workspace } from '../../src/workspace';
 import { BzlLibraryGenerator } from '../../src/generators/bzl/bzl-library.generator';

--- a/test/generators/filegroup.generator.spec.ts
+++ b/test/generators/filegroup.generator.spec.ts
@@ -1,4 +1,4 @@
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 
 import { Workspace } from '../../src/workspace';
 import { FilegroupGenerator } from '../../src/generators/builtin/filegroup.generator';

--- a/test/generators/ng.generator.spec.ts
+++ b/test/generators/ng.generator.spec.ts
@@ -1,4 +1,4 @@
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 
 import { setupAndParseArgs } from '../../src/flags';
 import { NgGenerator } from '../../src/generators/ng/ng.generator';

--- a/test/generators/sass.generator.spec.ts
+++ b/test/generators/sass.generator.spec.ts
@@ -1,4 +1,4 @@
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 
 import { setupAndParseArgs } from '../../src/flags';
 import { SassGenerator } from '../../src/generators/sass/sass.generator';

--- a/test/generators/ts.generator.spec.ts
+++ b/test/generators/ts.generator.spec.ts
@@ -1,4 +1,4 @@
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 
 import { CommonFlags, setupAndParseArgs } from '../../src/flags';
 import { TsGenerator } from '../../src/generators/ts/ts.generator';

--- a/test/workspace.spec.ts
+++ b/test/workspace.spec.ts
@@ -1,4 +1,4 @@
-import * as mockfs from 'mock-fs';
+import mockfs from 'mock-fs';
 
 import { setupAndParseArgs } from '../src/flags';
 import { Workspace } from '../src/workspace';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         ],
         "moduleResolution": "node",
         "experimentalDecorators": true,
-        "emitDecoratorMetadata": true
+        "emitDecoratorMetadata": true,
+        "esModuleInterop": true
     }
 }


### PR DESCRIPTION
This is due to an internal change in ev/tooling. Evertz staff see ev/#2285